### PR TITLE
fix: moved from spaceless tag to spaceless filter

### DIFF
--- a/src/Resources/views/Audit/helper.html.twig
+++ b/src/Resources/views/Audit/helper.html.twig
@@ -1,5 +1,5 @@
 {% macro dump(value, separator) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if value.label is defined %}
             {{ value.label }}
         {% elseif value is iterable %}
@@ -9,7 +9,7 @@
         {% else %}
             {{ value is same as(false) ? '0' : value }}
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro dump %}
 
 


### PR DESCRIPTION
starting from Twig 1.38 and 2.7.3, the spaceless tag has been deprecated in favour of the spaceless filter. 
In Twig 3 spaceless has been removed.